### PR TITLE
Switch back to using the standard buildah task

### DIFF
--- a/.tekton/fedora-flatpak-runtime-pull-request.yaml
+++ b/.tekton/fedora-flatpak-runtime-pull-request.yaml
@@ -234,13 +234,11 @@ spec:
         params:
         - name: name
           value: buildah
-        - name: url
-          value: https://github.com/owtaylor/build-definitions.git
-        - name: revision
-          value: flatpak
-        - name: pathInRepo
-          value: task/buildah/0.1/buildah.yaml
-        resolver: git
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:1473e72a7e191a2480767616257f9dc72d3a189628897991b6255f2bf8f1bf69
+        - name: kind
+          value: task
+        resolver: bundles
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/fedora-flatpak-runtime-pull-request.yaml
+++ b/.tekton/fedora-flatpak-runtime-pull-request.yaml
@@ -233,9 +233,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-8gb
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:1473e72a7e191a2480767616257f9dc72d3a189628897991b6255f2bf8f1bf69
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-8gb:0.1@sha256:63b169d8e8948ebf6cd0bcb21aa82c2757bd75fba8e52cb4f1eb9fd55d8c008c
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/fedora-flatpak-runtime-push.yaml
+++ b/.tekton/fedora-flatpak-runtime-push.yaml
@@ -230,13 +230,11 @@ spec:
         params:
         - name: name
           value: buildah
-        - name: url
-          value: https://github.com/owtaylor/build-definitions.git
-        - name: revision
-          value: flatpak
-        - name: pathInRepo
-          value: task/buildah/0.1/buildah.yaml
-        resolver: git
+        - name: bundle
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:1473e72a7e191a2480767616257f9dc72d3a189628897991b6255f2bf8f1bf69
+        - name: kind
+          value: task
+        resolver: bundles
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/fedora-flatpak-runtime-push.yaml
+++ b/.tekton/fedora-flatpak-runtime-push.yaml
@@ -229,9 +229,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-8gb
         - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:1473e72a7e191a2480767616257f9dc72d3a189628897991b6255f2bf8f1bf69
+          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah-8gb:0.1@sha256:63b169d8e8948ebf6cd0bcb21aa82c2757bd75fba8e52cb4f1eb9fd55d8c008c
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Now that https://github.com/konflux-ci/build-definitions/pull/1017 has been merged and the ADD_CAPABILITIES parameter is supported, we can switch back to using the standard buildah task.